### PR TITLE
Fix import

### DIFF
--- a/src/backends/beamcoder.ts
+++ b/src/backends/beamcoder.ts
@@ -12,7 +12,7 @@ import type {
 import {
     BaseExtractor
 } from '../BaseExtractor.js';
-import { DownloadVideoURL } from '../DownloadVideoURL';
+import { DownloadVideoURL } from '../DownloadVideoURL.js';
 
 const LOG_PACKET_FLOW = false;
 const LOG_SINGLE_FRAME_DUMP_FLOW = false;


### PR DESCRIPTION
For some reason, when using [ESM](https://www.typescriptlang.org/docs/handbook/esm-node.html) modules, we have to add `.js` (even if the file is `.ts`). I'm not sure why.