### PR TITLE
Also emit CommonJS build

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,13 +55,12 @@
     "vitest": "^0.29.2"
   },
   "description": "Video library",
-  "main": "./dist/framefusion.es.js",
-  "types": "./dist/framefusion.d.ts",
-  "module": "./dist/framefusion.es.js",
+  "main": "./dist/framefusion.js",
   "exports": {
     ".": {
-      "types": "./dist/framefusion.d.ts",
-      "import": "./dist/framefusion.es.js"
+      "require": "./dist/framefusion.cjs",
+      "import": "./dist/framefusion.es.js",
+      "types": "./dist/framefusion.d.ts"
     }
   },
   "files": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,11 +9,20 @@ export default defineConfig({
         lib: {
             entry: path.resolve(__dirname, 'framefusion.ts'),
             name: 'framefusion.ts',
-            fileName: (format) => `framefusion.${format}.js`,
-            formats: ['es'],
+            fileName: (format) => {
+                if (format === 'es') {
+                    return 'framefusion.es.js';
+                }
+                if (format === 'cjs') {
+                    return 'framefusion.cjs';
+                }
+
+                throw new Error(`Please provide a fileName for ${format}`);
+            },
+            formats: ['es', 'cjs'],
         },
         rollupOptions: {
-            external: [],
+            external: ['node:https'],
         },
         sourcemap: true,
     },


### PR DESCRIPTION
Currently, we are just emitting esm modules - now, we'll also be able to use framefusion in commonjs projects (most node projects are still using commonjs).