### PR TITLE
Update interface to ImageData instead of beamcoder.Frame and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ async function run() {
     });
 
     // Get frame at a specific time (in seconds)
-    const imageData = await extractor.getFrameImageDataAtTime(2.0);
+    const imageData = await extractor.getImageDataAtTime(2.0);
 
     // Do something with frame data
     console.log(imageData);

--- a/examples/mini-framefusion-example/main.ts
+++ b/examples/mini-framefusion-example/main.ts
@@ -9,7 +9,7 @@ async function run() {
     });
 
     // Get frame at a specific time (in seconds)
-    const frame = await extractor.getFrameImageDataAtTime(2.0);
+    const frame = await extractor.getImageDataAtTime(2.0);
 
     // Do something with frame data
     console.log(frame.data);

--- a/framefusion.ts
+++ b/framefusion.ts
@@ -32,7 +32,7 @@ export interface Extractor {
 
     get height(): number;
 
-    getFrameAtTime(targetTime: number): Promise<Frame>;
+    getFrameImageDataAtTime(targetTime: number): Promise<ImageData>;
 
     dispose(): Promise<void>;
 }

--- a/framefusion.ts
+++ b/framefusion.ts
@@ -32,6 +32,8 @@ export interface Extractor {
 
     get height(): number;
 
+    getFrameAtTime(targetTime: number): Promise<Frame>;
+
     getFrameImageDataAtTime(targetTime: number): Promise<ImageData>;
 
     dispose(): Promise<void>;

--- a/framefusion.ts
+++ b/framefusion.ts
@@ -1,3 +1,4 @@
+import type { ImageData } from 'canvas';
 import { BeamcoderExtractor } from './src/backends/beamcoder.js';
 
 export type Frame = {
@@ -34,7 +35,7 @@ export interface Extractor {
 
     getFrameAtTime(targetTime: number): Promise<Frame>;
 
-    getFrameImageDataAtTime(targetTime: number): Promise<ImageData>;
+    getImageDataAtTime(targetTime: number): Promise<ImageData>;
 
     dispose(): Promise<void>;
 }
@@ -61,7 +62,7 @@ export interface Extractor {
 //         inputFileOrUrl: TEST_VIDEO,
 //     });
 //
-//     const frame = await extractor.getFrameImageDataAtTime(0.3);
+//     const frame = await extractor.getImageDataAtTime(0.3);
 //     console.log(frame);
 //     extractor.dispose();
 // };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumen5/framefusion",
-  "version": "0.0.4",
+  "version": "0.0.11",
   "type": "module",
   "scripts": {
     "docs": "typedoc framefusion.ts",

--- a/src/BaseExtractor.ts
+++ b/src/BaseExtractor.ts
@@ -1,3 +1,5 @@
+import type { ImageData } from 'canvas';
+
 import type {
     ExtractorArgs,
     Frame,
@@ -37,6 +39,10 @@ export class BaseExtractor implements Extractor {
     }
 
     async getFrameAtTime(targetTime: number): Promise<Frame> {
+        throw new Error('Not implemented');
+    }
+
+    async getImageDataAtTime(targetTime: number): Promise<ImageData> {
         throw new Error('Not implemented');
     }
 

--- a/src/backends/beamcoder.ts
+++ b/src/backends/beamcoder.ts
@@ -373,7 +373,7 @@ export class BeamcoderExtractor extends BaseExtractor implements Extractor {
      *
      * @see getFrameAtTime()
      */
-    async getFrameImageDataAtTime(targetTime: number): Promise<ImageData> {
+    async getImageDataAtTime(targetTime: number): Promise<ImageData> {
         LOG_SINGLE_FRAME_DUMP_FLOW && console.log(`Requesting to dump a frame at Time(s)=${targetTime}`);
         const targetPts = Math.floor(this.timeToPts(targetTime));
         const frame = await this.getFrameAtPts(targetPts);

--- a/test/framefusion.test.ts
+++ b/test/framefusion.test.ts
@@ -287,7 +287,7 @@ describe('framefusion', () => {
 
             // Act & assert
             for (let i = 0; i < 10; i++) {
-                const imagedata = await extractor.getFrameImageDataAtTime(i / 30.0 + FRAME_SYNC_DELTA);
+                const imagedata = await extractor.getImageDataAtTime(i / 30.0 + FRAME_SYNC_DELTA);
                 expect(imagedata.width).to.equal(extractor.width);
                 expect(imagedata.height).to.equal(extractor.height);
                 const canvas = createCanvas(imagedata.width, imagedata.height);


### PR DESCRIPTION
Currently, the base interface exposes the (now) internal frame getter instead of ImageData getter.

Also, our github version are too far in advance - due to early CI testing: https://github.com/Lumen5/framefusion/releases - So I'm bumping the package version further to be able to sync both package and github release version.