### PR TITLE
Another seeking fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumen5/framefusion",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "type": "module",
   "scripts": {
     "docs": "typedoc framefusion.ts",

--- a/src/backends/beamcoder.ts
+++ b/src/backends/beamcoder.ts
@@ -152,6 +152,10 @@ export class BeamcoderExtractor extends BaseExtractor implements Extractor {
      */
     #streamIndex = 0;
 
+    /**
+     * The number of packets we've read from the demuxer to complete the frame query
+     * @private
+     */
     #packetReadCount = 0;
 
     /**

--- a/test/framefusion.test.ts
+++ b/test/framefusion.test.ts
@@ -73,6 +73,24 @@ describe('FrameFusion', () => {
         await extractor.dispose();
     });
 
+    it('only reads a few packets to get the next frame after a seek', async() => {
+        const extractor = await BeamcoderExtractor.create({
+            inputFileOrUrl: 'https://storage.googleapis.com/lumen5-prod-video/mvc-4k-new-orleans-a053c0340725rv-112014WA74Rf.mp4',
+        });
+
+        const offset = 1.0 * FPS;
+        for (let i = offset; i < offset + 10; i++) {
+            const time = i / FPS + FRAME_SYNC_DELTA;
+            await extractor.getFrameAtTime(time);
+
+            // for the first frame query we have to find the closest PTS and read several packets to get the closest
+            // frame, after that we should only have to read a few packets
+            if (i > offset + 2) {
+                expect(extractor.packetReadCount).to.equal(1);
+            }
+        }
+    });
+
     it('can identify video stream index', async() => {
         // Arrange
         const extractor = await BeamcoderExtractor.create({


### PR DESCRIPTION
Getting frames for `https://storage.googleapis.com/lumen5-prod-video/mvc-4k-new-orleans-a053c0340725rv-112014WA74Rf.mp4` would get progressively slower. That was because we forgot to update our `this.#previousTargetPTS` in one use case, which resulted in excessive seeking. In this PR, fix this. 

// before
query:  30 - passed time:  65ms - packages read: 41
query: 128 - passed time: 149ms - packages read: 139
query: 320 - passed time: 102ms - packages read: 81
query: 438 - passed time: 214ms - packages read: 199

// after
query:  30 - passed time: 89ms - packages read: 41
query: 128 - passed time:  2ms - packages read: 1
query: 320 - passed time:  2ms - packages read: 1
query: 438 - passed time:  1ms - packages read: 1