### PR TITLE
Add re-seek delta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumen5/framefusion",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "type": "module",
   "scripts": {
     "docs": "typedoc framefusion.ts",


### PR DESCRIPTION
Looks like Luminary seeks to 0 when starting.

This means the next time we seek, we have to read all packets. This is why I'm adding a threshold (RE_SEEK_DELTA) after which we should seek again and start decoding closer to the time we want a frame at.