### PR TITLE
Add a new packet read count test

### DIFF
--- a/test/framefusion.test.ts
+++ b/test/framefusion.test.ts
@@ -89,7 +89,31 @@ describe('FrameFusion', () => {
                 expect(extractor.packetReadCount).to.equal(1);
             }
         }
+
+        // Cleanup
+        await extractor.dispose();
     });
+
+    it('Only reads a few packets when getting frames which are far apart', async() => {
+        // Arrange
+        const extractor = await BeamcoderExtractor.create({
+            inputFileOrUrl: 'https://storage.googleapis.com/lumen5-prod-video/mvc-4k-new-orleans-a053c0340725rv-112014WA74Rf.mp4',
+        });
+
+        // Act & assert
+        await extractor.getFrameAtTime(0);
+        expect(extractor.packetReadCount).to.be.below(15);
+
+        await extractor.getFrameAtTime(20);
+        expect(extractor.packetReadCount).to.be.below(15);
+
+        await extractor.getFrameAtTime(0);
+        expect(extractor.packetReadCount).to.be.below(15);
+
+        // Cleanup
+        await extractor.dispose();
+    });
+
 
     it('can identify video stream index', async() => {
         // Arrange


### PR DESCRIPTION
Here is this test failing without the fix:

<img width="846" alt="image" src="https://github.com/Lumen5/framefusion/assets/2675724/3a49c998-fc08-4af0-a5d4-87db98d2c27f">

This edge case was pretty frequent, since we often seek to 0, then seek to a different time.

Before this morning's fix (RE_SEEK_THRESHOLD), we would read all packets until the target (501 packets in the screenshot!). With RE_SEEK_THRESHOLD, we skip to a closer position when appropriate.