### PR TITLE
Frame not found fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumen5/framefusion",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "type": "module",
   "scripts": {
     "docs": "typedoc framefusion.ts",

--- a/src/backends/beamcoder.ts
+++ b/src/backends/beamcoder.ts
@@ -407,7 +407,7 @@ export class BeamcoderExtractor extends BaseExtractor implements Extractor {
         // the end of the video and try again. We've set up a MAX_RECURSION to prevent an infinite loop.
         if (!outputFrame) {
             if (MAX_RECURSION < this.#recursiveReadCount) {
-                throw Error(`Unable to find frame`);
+                throw Error('No matching frame found');
             }
             const TIME_OFFSET = 0.1; // time offset in seconds
             const PTSOffset = this._timeToPTS(TIME_OFFSET);

--- a/src/backends/beamcoder.ts
+++ b/src/backends/beamcoder.ts
@@ -94,7 +94,7 @@ const createFilter = async({
 
 const STREAM_TYPE_VIDEO = 'video';
 const COLORSPACE_RGBA = 'rgba';
-const MAX_RECURSION = 2;
+const MAX_RECURSION = 5;
 
 /**
  * A simple extractor that uses beamcoder to extract frames from a video file.


### PR DESCRIPTION
In this PR, we're dealing with a new edge case. A video with an audio stream twice as long as the video stream. When this was the case:
- we didn't return the correct duration (we returned the audio duration instead of the video duration)
- we weren't able to find frames when we previously flushed our decoder, which happens when we're looking for frames toward the end of the video
- we couldn't find frames close towards the end of the video (as the packets wouldn't contain any frames). 

These issues have been addressed here.

TODO
- Add a test where we query a frame after the end of the video (currentTime > video.duration)
- Test our new logic with a few more videos