### PR TITLE
fix(*): handle timeout

### DIFF
--- a/src/DownloadVideoURL.ts
+++ b/src/DownloadVideoURL.ts
@@ -62,6 +62,11 @@ export class DownloadVideoURL {
                     }
                     reject(e);
                 });
+
+                this.#httpRequest.on('timeout', () => {
+                    this.#httpRequest.destroy();
+                    reject(new Error(`Request to ${source} timed out`));
+                });
             }
             catch (e) {
                 reject(e);


### PR DESCRIPTION
As part of my investigation related to simple-get timeout I want to figure out what's difference between loading images and video.
We don't see any errors related to video loading in our bugsnag, but we see it for images.
My guess is that we have same problems with video downloading but exception is just swallowed
Simple get is a simple wrapper around http.get,
This is how it handles timeout
https://github.com/feross/simple-get/blob/master/index.js#L74
So, here I'm adding the same logic