### PR TITLE
LU-3176: optimize getImageDataAtTime

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumen5/framefusion",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "docs": "typedoc framefusion.ts",

--- a/src/backends/beamcoder.ts
+++ b/src/backends/beamcoder.ts
@@ -13,6 +13,11 @@ import { DownloadVideoURL } from '../DownloadVideoURL';
 
 const VERBOSE = false;
 
+/**
+ * RGBA format need one byte for every components: r, g, b and a
+ */
+const RGBA_PIXEL_SIZE = 4;
+
 const createDecoder = ({
     demuxer,
     streamIndex,
@@ -258,7 +263,7 @@ export class BeamcoderExtractor extends BaseExtractor implements Extractor {
         let rawData = target;
 
         if (!target) {
-            rawData = new Uint8ClampedArray(frame.width * frame.height * 4);
+            rawData = new Uint8ClampedArray(frame.width * frame.height * RGBA_PIXEL_SIZE);
         }
 
         this._setFrameDataToImageData(frame, rawData);
@@ -484,7 +489,6 @@ export class BeamcoderExtractor extends BaseExtractor implements Extractor {
     }
 
     _setFrameDataToImageData(frame: beamcoder.Frame, target: Uint8ClampedArray) {
-        const components = 4; // 4 components: r, g, b and a
         const sourceLineSize = frame.linesize as unknown as number;
         // frame.data can contain multiple "planes" in other colorspaces, but in rgba, there is just one "plane", so
         // our data is in frame.data[0]
@@ -495,9 +499,9 @@ export class BeamcoderExtractor extends BaseExtractor implements Extractor {
 
         for (let i = 0; i < frame.height; i++) {
             const sourceStart = i * sourceLineSize;
-            const sourceEnd = sourceStart + frame.width * components;
+            const sourceEnd = sourceStart + frame.width * RGBA_PIXEL_SIZE;
             const sourceData = pixels.subarray(sourceStart, sourceEnd);
-            const targetOffset = i * frame.width * components;
+            const targetOffset = i * frame.width * RGBA_PIXEL_SIZE;
             target.set(sourceData, targetOffset);
         }
     }

--- a/src/backends/beamcoder.ts
+++ b/src/backends/beamcoder.ts
@@ -491,7 +491,7 @@ export class BeamcoderExtractor extends BaseExtractor implements Extractor {
         // libav creates larger buffers by 16 bytes because it makes their internal code simpler.
         // we have to trim a part at the end.
 
-        target.set(pixels.subarray(0, target.length));
+        target.set(pixels.slice(0, target.length));
     }
 
     async dispose() {

--- a/src/backends/beamcoder.ts
+++ b/src/backends/beamcoder.ts
@@ -495,7 +495,6 @@ export class BeamcoderExtractor extends BaseExtractor implements Extractor {
 
         for (let i = 0; i < frame.height; i++) {
             const sourceStart = i * sourceLineSize;
-            // console.log('sourceStart', sourceStart)
             const sourceEnd = sourceStart + frame.width * components;
             const sourceData = pixels.subarray(sourceStart, sourceEnd);
             const targetOffset = i * frame.width * components;


### PR DESCRIPTION
It's somthing we wanted to do 
1) we wanted to reuse existing buffer for specific video element instead of re allocating it for every frame

2) we don't need to copy beamcoder.frame, it's enough for us to create a view of typed array if we can guarantee that beamcoder frame will not be detached,

It improves GC