### PR TITLE
add support for file urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumen5/framefusion",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "scripts": {
     "docs": "typedoc framefusion.ts",

--- a/src/backends/beamcoder.ts
+++ b/src/backends/beamcoder.ts
@@ -191,7 +191,11 @@ export class BeamcoderExtractor extends BaseExtractor implements Extractor {
             inputFileOrUrl = downloadUrl.filepath;
             VERBOSE && console.log('finished downloading');
         }
-        this.#demuxer = await beamcoder.demuxer('file:' + inputFileOrUrl);
+        // Assume file url at this point
+        if (!inputFileOrUrl.startsWith('file:')) {
+            inputFileOrUrl = 'file:' + inputFileOrUrl;
+        }
+        this.#demuxer = await beamcoder.demuxer(inputFileOrUrl);
         this.#streamIndex = this.#demuxer.streams.findIndex(stream => stream.codecpar.codec_type === STREAM_TYPE_VIDEO);
         if (this.#streamIndex === -1) {
             throw new Error(`File has no ${STREAM_TYPE_VIDEO} stream!`);


### PR DESCRIPTION
Previously, the file input path assumed that it would never have the `file:` prefix (for a "file url"). This adds support so we can also pass a file url directly.