### PR TITLE
LU-3510 Adding duration support for webm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumen5/framefusion",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "type": "module",
   "scripts": {
     "docs": "typedoc framefusion.ts",

--- a/src/backends/beamcoder.ts
+++ b/src/backends/beamcoder.ts
@@ -18,13 +18,6 @@ const VERBOSE = false;
  */
 const RGBA_PIXEL_SIZE = 4;
 
-// Convert a duration string in the format HH:MM:SS to seconds
-// Example: 00:01:30 -> 90
-function convertDurationToSeconds(duration) {
-    const [hours, minutes, seconds] = duration.split(':').map(parseFloat);
-    return hours * 3600 + minutes * 60 + seconds;
-}
-
 const createDecoder = ({
     demuxer,
     streamIndex,
@@ -253,10 +246,7 @@ export class BeamcoderExtractor extends BaseExtractor implements Extractor {
         if (stream.duration !== null) {
             return this.ptsToTime(stream.duration);
         }
-        if (stream?.metadata?.DURATION) {
-            return convertDurationToSeconds(stream.metadata.DURATION);
-        }
-        return 0;
+        return this.ptsToTime(this.#demuxer.duration) / 1000;
     }
 
     /**

--- a/src/backends/beamcoder.ts
+++ b/src/backends/beamcoder.ts
@@ -41,8 +41,6 @@ const createDecoder = ({
         thread_count: threadCount,
     };
 
-    console.log('codec', demuxer.streams[streamIndex].codecpar.name);
-
     if (demuxer.streams[streamIndex].codecpar.name === 'vp8') {
         return beamcoder.decoder({
             ...commonParams,

--- a/test/framefusion.test.ts
+++ b/test/framefusion.test.ts
@@ -73,7 +73,7 @@ describe('FrameFusion', () => {
         await extractor.dispose();
     });
 
-    it('can get duration from webm', async() => {
+    it.only('can get duration from webm', async() => {
         // Arrange
         const extractor = await BeamcoderExtractor.create({
             inputFileOrUrl: 'https://storage.googleapis.com/lumen5-prod-video/anita-6uTzyZtNRIqOTag.webm',

--- a/test/framefusion.test.ts
+++ b/test/framefusion.test.ts
@@ -73,7 +73,7 @@ describe('FrameFusion', () => {
         await extractor.dispose();
     });
 
-    it.only('can get duration from webm', async() => {
+    it('can get duration from webm', async() => {
         // Arrange
         const extractor = await BeamcoderExtractor.create({
             inputFileOrUrl: 'https://storage.googleapis.com/lumen5-prod-video/anita-6uTzyZtNRIqOTag.webm',

--- a/test/framefusion.test.ts
+++ b/test/framefusion.test.ts
@@ -73,7 +73,7 @@ describe('FrameFusion', () => {
         await extractor.dispose();
     });
 
-    it.only('can get duration from webm', async() => {
+    it('can get duration from webm', async() => {
         // Arrange
         const extractor = await BeamcoderExtractor.create({
             inputFileOrUrl: 'https://storage.googleapis.com/lumen5-prod-video/anita-6uTzyZtNRKztypC.webm',

--- a/test/framefusion.test.ts
+++ b/test/framefusion.test.ts
@@ -73,14 +73,14 @@ describe('FrameFusion', () => {
         await extractor.dispose();
     });
 
-    it('can get duration from webm', async() => {
+    it.only('can get duration from webm', async() => {
         // Arrange
         const extractor = await BeamcoderExtractor.create({
             inputFileOrUrl: 'https://storage.googleapis.com/lumen5-prod-video/anita-6uTzyZtNRKztypC.webm',
         });
 
         // Act and Assert
-        expect(extractor.duration).to.equal(115);
+        expect(extractor.duration).to.equal(115.248);
 
         // Cleanup
         await extractor.dispose();

--- a/test/framefusion.test.ts
+++ b/test/framefusion.test.ts
@@ -73,10 +73,10 @@ describe('FrameFusion', () => {
         await extractor.dispose();
     });
 
-    it('can get duration from webm', async() => {
+    it.only('can get duration from webm', async() => {
         // Arrange
         const extractor = await BeamcoderExtractor.create({
-            inputFileOrUrl: 'https://storage.googleapis.com/lumen5-prod-video/anita-6uTzyZtNRIqOTag.webm',
+            inputFileOrUrl: 'https://storage.googleapis.com/lumen5-prod-video/anita-6uTzyZtNRKztypC.webm',
         });
 
         // Act and Assert

--- a/test/framefusion.test.ts
+++ b/test/framefusion.test.ts
@@ -60,7 +60,7 @@ describe('FrameFusion', () => {
         await extractor.dispose();
     });
 
-    it('can get duration', async() => {
+    it('can get duration from mp4', async() => {
         // Arrange
         const extractor = await BeamcoderExtractor.create({
             inputFileOrUrl: 'https://storage.googleapis.com/lumen5-prod-images/countTo60.mp4',
@@ -68,6 +68,19 @@ describe('FrameFusion', () => {
 
         // Act and Assert
         expect(extractor.duration).to.equal(2);
+
+        // Cleanup
+        await extractor.dispose();
+    });
+
+    it('can get duration from webm', async() => {
+        // Arrange
+        const extractor = await BeamcoderExtractor.create({
+            inputFileOrUrl: 'https://storage.googleapis.com/lumen5-prod-video/anita-6uTzyZtNRIqOTag.webm',
+        });
+
+        // Act and Assert
+        expect(extractor.duration).to.equal(115);
 
         // Cleanup
         await extractor.dispose();


### PR DESCRIPTION
The stream's duration can be `null`. In those cases, the duration may be described as part of the stream's metadata. We found that in our [webm's](https://storage.googleapis.com/lumen5-prod-video/anita-6uTzyZtNRIqOTag.webm) generated by D-ID. In this PR, we add to return the stream's metadata's duration if available. 

```
{
  "type": "Stream",
  "index": 0,
  "id": 0,
  "time_base": [
    1,
    1000
  ],
  "start_time": 0,
  "duration": null,
  "sample_aspect_ratio": [
    1,
    1
  ],
  "metadata": {
    "alpha_mode": "1",
    "ENCODER": "Lavc60.3.100 libvpx-vp9",
    "DURATION": "00:01:55.000000000"
  },
  "avg_frame_rate": [
    25,
    1
  ],
  "event_flags": {
    "METADATA_UPDATED": false
  },
  "r_frame_rate": [
    25,
    1
  ],
  "codecpar": {
    "type": "CodecParameters",
    "codec_type": "video",
    "codec_id": 167,
    "name": "vp9",
    "format": "yuv420p",
    "profile": "Profile 0",
    "width": 1080,
    "height": 1080,
    "field_order": "progressive",
    "color_range": "tv"
  }
}
```