### PR TITLE
feat(*): use fetch api

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumen5/framefusion",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "docs": "typedoc framefusion.ts",

--- a/src/DownloadVideoURL.ts
+++ b/src/DownloadVideoURL.ts
@@ -1,11 +1,9 @@
 import path from 'path';
-import https from 'node:https';
 import type { ClientRequest } from 'http';
-import http from 'http';
+
+import { Writable } from 'stream';
 import tmp from 'tmp';
 import fs from 'fs-extra';
-
-class CancelRequestError extends Error { }
 
 /**
  * Downloads a video file from a given URL as a temporary file. When the object is cleared, the temporary file is
@@ -26,49 +24,54 @@ export class DownloadVideoURL {
     }
 
     /**
-     * returns the filepath of the downloaded file. If the file has not been downloaded yet, it will be undefined
-     */
+   * returns the filepath of the downloaded file. If the file has not been downloaded yet, it will be undefined
+   */
     get filepath() {
         return this.#filepath;
     }
 
     /**
-     * Downloads the file from the given URL. The file will be downloaded to a temporary file.
-     */
+   * Downloads the file from the given URL. The file will be downloaded to a temporary file.
+   */
     async download() {
-        await new Promise<void>((resolve, reject) => {
-            const source = this.#url;
-            try {
-                const connectionHandler = source.startsWith('https://') ? https : http;
-                this.#httpRequest = connectionHandler.get(source, (res) => {
-                    const contentType = res.headers['content-type'];
-                    if (!contentType.includes('video')) {
-                        const err = new Error(`Source ${source}, returned unsupported content type ${contentType}`);
-                        reject(err);
-                        return;
-                    }
-                    const writeStream = fs.createWriteStream(this.#tmpObj.name);
-                    res.pipe(writeStream);
-                    writeStream.on('finish', () => {
-                        writeStream.close();
-                        this.#filepath = this.#tmpObj.name;
-                        resolve();
-                    });
-                    writeStream.on('error', (e) => {
-                        reject(e);
-                    });
+        const source = this.#url;
+        try {
+            const response = await fetch(source);
+            if (!response.ok) {
+                throw new Error(
+                    `Failed to fetch ${source}, status: ${response.status}`
+                );
+            }
+
+            const contentType = response.headers.get('content-type');
+            if (!contentType || !contentType.includes('video')) {
+                throw new Error(
+                    `Source ${source}, returned unsupported content type ${contentType}`
+                );
+            }
+
+            const writeStream = fs.createWriteStream(this.#tmpObj.name);
+            const readableStream = response.body;
+
+            if (!readableStream) {
+                throw new Error(`Response body is null for ${source}`);
+            }
+
+            await new Promise<void>((resolve, reject) => {
+                readableStream.pipeTo(Writable.toWeb(writeStream));
+                writeStream.on('finish', () => {
+                    writeStream.close();
+                    this.#filepath = this.#tmpObj.name;
+                    resolve();
                 });
-                this.#httpRequest.on('error', (e) => {
-                    if (e instanceof CancelRequestError) {
-                        return;
-                    }
+                writeStream.on('error', (e) => {
                     reject(e);
                 });
-            }
-            catch (e) {
-                reject(e);
-            }
-        });
+            });
+        }
+        catch (e) {
+            throw e;
+        }
     }
 
     clear() {


### PR DESCRIPTION
When we debug nwjs we don't see framefusion requests in network tab on dev tools.
This make debugging hard. This happens because we use api which is not supported in browser.
Here I'm migrating framefusion to use native fetch api