### PR TITLE
fix(*): use video duration

### DIFF
--- a/src/backends/beamcoder.ts
+++ b/src/backends/beamcoder.ts
@@ -243,10 +243,6 @@ export class BeamcoderExtractor extends BaseExtractor implements Extractor {
      * This is the duration of the first video stream in the file expressed in seconds.
      */
     get duration(): number {
-        const stream = this.#demuxer.streams[this.#streamIndex];
-        if (stream.duration !== null) {
-            return this.ptsToTime(stream.duration);
-        }
         return this.ptsToTime(this.#demuxer.duration) / 1000;
     }
 


### PR DESCRIPTION
I'm not sure why we use stream duration 