### PR TITLE
docs: bump README node guidance to 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ For a complete working project (with package.json, vite config, typescript confi
 
 # Running test
 
-Make sure you run node 18 or higher.
+Make sure you run node 24 or higher.
 
 ```bash
-nvm use 18
+nvm use 24
 yarn install && yarn run test-ui
 ```
 


### PR DESCRIPTION
Workflow files and ci.Dockerfile already use node 24. This bumps the README docs (`Make sure you run node 18 or higher` / `nvm use 18`) to match. Part of the org-wide Node 24 migration.