### PR TITLE
chore: use npm trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -22,8 +22,6 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
-      - name: Update npm for trusted publishing
-        run: npm install -g npm@latest
       - run: mkdir /tmp/framefusion
       - run: cp -r . /tmp/framefusion
       - run: sudo apt-get update && sudo apt-get install -y libvpx-dev

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     env:
       CPATH: /tmp/framefusion/.framefusion-ffmpeg/ffmpeg/include/
       PKG_CONFIG_PATH: /tmp/framefusion/.framefusion-ffmpeg/ffmpeg/lib/pkgconfig/
@@ -19,6 +22,8 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@latest
       - run: mkdir /tmp/framefusion
       - run: cp -r . /tmp/framefusion
       - run: sudo apt-get update && sudo apt-get install -y libvpx-dev
@@ -28,7 +33,5 @@ jobs:
         working-directory: /tmp/framefusion
       - run: yarn build
         working-directory: /tmp/framefusion
-      - run: yarn publish
+      - run: npm publish
         working-directory: /tmp/framefusion
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
## Summary
- Switch npm publish from classic token (expired 2026-04-13) to OIDC-based trusted publishing
- Switch publish step from `yarn publish` to `npm publish` (trusted publishing needs npm CLI 11.5.1+; yarn classic doesn't do the OIDC exchange)
- Trusted publisher already registered on npmjs.com for this package + this workflow file
- LUM-72

## Test plan
- [ ] Next GitHub release triggers the workflow and publishes successfully